### PR TITLE
Assume URL starts with https:// and parse it before other arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ pip install httpie-edgegrid
 The examples and guides on the developer portal are moving to this new tool, so please consider using it for your API calls.
 
 ## CHANGES
+2022-04-14
+* Reorder list of arguments before parsing it, moving URL to the beginning.
+
+2022-04-13
+* Pass unknown argument before known ones, to let -q be passed in 1st position and honored.
+
 2021-04-22
 * Added PATCH as a valid method argument.
 
@@ -110,7 +116,7 @@ The hostname segment of the url will be automatically replaced with the hostname
 $ ./egcurl --help
 usage: egcurl [-h] [-H HEADER] [--eg-edgerc EG_EDGERC | --eg-config EG_CONFIG]
               [--eg-json] [--eg-section EG_SECTION] [--eg-verbose]
-              [-d DATA | --data-binary DATA_BINARY] [-X {DELETE,GET,POST,PUT}]
+              [-d DATA | --data-binary DATA_BINARY] [-X {DELETE,GET,PATCH,POST,PUT}]
               url
 
 Akamai {OPEN} API utility for signed API requests with cURL.
@@ -126,23 +132,21 @@ optional arguments:
                         Location of EdgeRc configuration ini file.
   --eg-config EG_CONFIG
                         Location of older configuration file (DEPRECATED).
-  --eg-json             Automatically apply JSON pretty-format to the
-                        response.
+  --eg-json             Automatically apply JSON pretty-format to the response.
   --eg-section EG_SECTION
-                        Section of the config file for the desired OPEN API
-                        credentials.
+                        Section of the config file for the desired OPEN API credentials.
   --eg-verbose          Enable verbose logging output (repeat for even more)
   -d DATA, --data DATA, --data-ascii DATA
                         ASCII data content for POST body
   --data-binary DATA_BINARY
                         binary data content for POST body
-  -X {DELETE,GET,POST,PUT}, --method {DELETE,GET,POST,PUT}
+  -X {DELETE,GET,PATCH,POST,PUT}, --method {DELETE,GET,PATCH,POST,PUT}, --request {DELETE,GET,PATCH,POST,PUT}
                         HTTP method for the request
 
-Several arguments above as well as any unlisted arguments are passed on to
-curl. The <url> argument should always be the final argument. The url hostname
-will automatically be replaced with the one specified by the selected
-configuration section.
+Several arguments above as well as any unlisted arguments are passed on to cURL,
+starting with unlisted arguments followed by URL. The <url> argument should always be
+the first item starting with "https://". The URL hostname will automatically be replaced
+with the one specified by the selected configuration section.
 ```
 
 ## EXAMPLE

--- a/egcurl
+++ b/egcurl
@@ -165,7 +165,7 @@ def _parse_fields(config, line):
 
 def get_parser():
     parser = argparse.ArgumentParser(description='Akamai {OPEN} API utility for signed API requests with cURL.',
-                                     epilog='Several arguments above as well as any unlisted arguments are passed on to curl. The <url> argument should always be the final argument. The url hostname will automatically be replaced with the one specified by the selected configuration section.')
+                                     epilog='Several arguments above as well as any unlisted arguments are passed on to cURL, starting with unlisted arguments followed by URL. The <url> argument should always be the first item starting with "https://". The URL hostname will automatically be replaced with the one specified by the selected configuration section.')
     parser.add_argument('-H', '--header',
                         action='append',
                         default = [],
@@ -199,7 +199,39 @@ def get_parser():
                         default='GET')
     parser.add_argument('url',
                         help='Request URL')
-    (args, args_unknown) = parser.parse_known_args()
+
+    # Reorder list of arguments before parsing it, moving URL to the beginning
+    # This assumes that the URL is the first item starting with "https://"
+    # This requires in particular that:
+    # - there is no cURL arguments like --data or --doh-url provided before the URL with a value starting also with "https://"
+    # - cURL option like --proto-default https is not used to pass URL that don't start with "https://" (as in curl --proto-default https www.example.com)
+
+    # Index of all items starting with "https://"
+    url_indexes=[sys.argv.index(x) for x in sys.argv if x.startswith("https://")]
+    if len(url_indexes) != 0:
+            # Old position of URL
+            url_index = url_indexes[0]
+            # New position of URL
+            url_index_new = 1
+            if url_index_new < url_index:
+                # Items before new position of URL
+                args_ordered = sys.argv[0:url_index_new]
+                # URL
+                args_ordered += [sys.argv[url_index]]
+                # Items between new and old position of URL
+                args_ordered += sys.argv[url_index_new:url_index]
+                # Items after old position of URL
+                args_ordered += sys.argv[url_index+1:len(sys.argv)]
+            else:
+                # URL can't be moved closer to the beginnig. Parse arguments without reordering them
+                args_ordered = sys.argv.copy()
+    else:
+        # URL not found. Parse arguments without reordering them
+        args_ordered = sys.argv.copy()
+    # Don't parse 1st item (program path)
+    args_ordered = args_ordered[1:]
+
+    (args, args_unknown) = parser.parse_known_args(args_ordered)
     if args.eg_verbose == 1:
         log.setLevel(logging.INFO)
     elif args.eg_verbose >= 2:
@@ -284,6 +316,7 @@ def main():
     log.info("Authorization header: %s", auth_header)
 
     curl_args = ([ 'curl' ])
+    # Pass unknown args before known ones, so that -q can be passed in 1st position
     curl_args.extend( args_unknown )
     curl_args.extend([ '-X', method, '-H', 'Authorization:' + auth_header, '-H', 'Expect:' ])
     for header in args.header:


### PR DESCRIPTION
This is meant to address this issue: https://github.com/akamai/edgegrid-curl/issues/31

These tests succeeded:
# url OK (in the middle)
./egcurl --eg-verbose --eg-verbose -q --config /home/aberdin/.curlrc.noheader https://luna.akamaiapis.net/identity-management/v2/api-clients/self/credentials -H"test:test"

#url OK (in 1st position)
./egcurl https://luna.akamaiapis.net/identity-management/v2/api-clients/self/credentials --eg-verbose --eg-verbose -q --config ~/.curlrc.noheader  -H"test:test"

#url OK (in last position)
./egcurl --eg-verbose --eg-verbose -q --config ~/.curlrc.noheader  -H"test:test" https://luna.akamaiapis.net/identity-management/v2/api-clients/self/credentials

These tests failed, as I expected:
#error url not starting with "https://"
./egcurl --eg-verbose --eg-verbose -q --config ~/.curlrc.noheader  -H"test:test" luna.akamaiapis.net/identity-management/v2/api-clients/self/credentials --proto-default https

#url after 1st item starting with "https://"
./egcurl --eg-verbose --eg-verbose -q --config ~/.curlrc.noheader  -H "https://" https://luna.akamaiapis.net/identity-management/v2/api-clients/self/credentials
